### PR TITLE
Added the missing maxlength reference in created()

### DIFF
--- a/fxos-text-input.js
+++ b/fxos-text-input.js
@@ -91,6 +91,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    this.clearable = this.hasAttribute('clearable');
 	    this.placeholder = this.getAttribute('placeholder');
 	    this.required = this.getAttribute('required');
+	    this.maxlength = this.getAttribute('maxlength');
 	    this.value = this.getAttribute('value');
 
 	    // Don't take focus from the input field

--- a/src/fxos-text-input.js
+++ b/src/fxos-text-input.js
@@ -35,6 +35,7 @@ module.exports = component.register('fxos-text-input', {
     this.clearable = this.hasAttribute('clearable');
     this.placeholder = this.getAttribute('placeholder');
     this.required = this.getAttribute('required');
+    this.maxlength = this.getAttribute('maxlength');
     this.value = this.getAttribute('value');
 
     // Don't take focus from the input field


### PR DESCRIPTION
@wilsonpage: Hi Wilson, think the maxlength reference is missing in the created() part. Found this when I was looking into [Bug 1232818](https://bugzilla.mozilla.org/show_bug.cgi?id=1232818). I think this fixes the issue but I have trouble getting the test cases running on my machine so could not 100% confirm it. 

Please take a look. Thanks! 
