### PR TITLE
Changed inputmode to x-inputmode for it to work in FxOS

### DIFF
--- a/fxos-text-input-pin.js
+++ b/fxos-text-input-pin.js
@@ -191,7 +191,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    <div class="inner">
 	      <content select="label"></content>
 	      <div class="container">
-	        <input type="password" inputmode="digit"/>
+	        <input type="password" x-inputmode="digit"/>
 	        <div class="fields" aria-hidden="true"></div>
 	      </div>
 	    </div>

--- a/src/fxos-text-input-pin.js
+++ b/src/fxos-text-input-pin.js
@@ -135,7 +135,7 @@ module.exports = component.register('fxos-text-input-pin', {
     <div class="inner">
       <content select="label"></content>
       <div class="container">
-        <input type="password" inputmode="digit"/>
+        <input type="password" x-inputmode="digit"/>
         <div class="fields" aria-hidden="true"></div>
       </div>
     </div>


### PR DESCRIPTION
The 'inputmode' attribute should be 'x-inputmode' for it to work in FxOS.
